### PR TITLE
Fix: Jest setup for babel 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-navigation": "^2.18.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.1.2",
     "@babel/preset-typescript": "^7.1.0",
     "@types/expo": "30.0.0",
     "@types/expo__vector-icons": "6.2.3",
@@ -28,10 +29,13 @@
     "@types/react-native": "0.57.7",
     "@types/react-navigation": "2.13.0",
     "@types/react-test-renderer": "^16.0.3",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-jest": "^23.6.0",
     "babel-plugin-module-resolver": "^3.1.1",
     "babel-preset-expo": "^5.0.0",
     "jest-config": "^23.6.0",
     "jest-expo": "^31.0.0",
+    "regenerator-runtime": "^0.12.1",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "typescript": "^3.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0", "@babel/core@^7.1.0":
+"@babel/core@^7.0.0", "@babel/core@^7.1.0", "@babel/core@^7.1.2":
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.1.2.tgz#f8d2a9ceb6832887329a7b60f9d035791400ba4e"
   dependencies:
@@ -1040,6 +1040,7 @@ babel-helpers@^6.24.1:
 babel-jest@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-23.6.0.tgz#a644232366557a2240a0c083da6b25786185a2f1"
+  integrity sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==
   dependencies:
     babel-plugin-istanbul "^4.1.6"
     babel-preset-jest "^23.2.0"
@@ -5081,7 +5082,7 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
-regenerator-runtime@^0.12.0:
+regenerator-runtime@^0.12.0, regenerator-runtime@^0.12.1:
   version "0.12.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
 


### PR DESCRIPTION
Fixes Jest setup as per instructions for babel 7: https://jestjs.io/docs/en/getting-started#using-babel

Test still fails due to potential stale snapshot. I'll let you look into this :)